### PR TITLE
Implement basic Battleship game UI and logic

### DIFF
--- a/Battleship.Core/AiPlayer.cs
+++ b/Battleship.Core/AiPlayer.cs
@@ -1,9 +1,29 @@
+using System;
+using System.Collections.Generic;
+
 namespace Battleship.Core;
 
 public class AiPlayer
 {
-    public void MakeMove()
+    private readonly Random _rnd = new();
+
+    public void AutoPlaceShips(Board board)
     {
-        // TODO: Implement AI logic
+        board.AutoPlaceShips();
+    }
+
+    public (int x, int y) ChooseShot(Board enemyBoard)
+    {
+        var available = new List<(int x, int y)>();
+        for (int x = 0; x < Board.Size; x++)
+            for (int y = 0; y < Board.Size; y++)
+            {
+                var state = enemyBoard.Cells[x, y];
+                if (state == CellState.Empty || state == CellState.Ship)
+                    available.Add((x, y));
+            }
+        if (available.Count == 0)
+            return (0, 0);
+        return available[_rnd.Next(available.Count)];
     }
 }

--- a/Battleship.Core/Board.cs
+++ b/Battleship.Core/Board.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Battleship.Core;
+
+public class Board
+{
+    public const int Size = 10;
+    private readonly CellState[,] _cells = new CellState[Size, Size];
+    private readonly List<Ship> _ships = new();
+    private static readonly int[] _shipSizes = { 4, 3, 3, 2, 2, 2, 1, 1, 1, 1 };
+
+    public CellState[,] Cells => _cells;
+    public IReadOnlyList<Ship> Ships => _ships;
+    public int ShipsRemaining => _ships.Count(s => !s.IsSunk);
+
+    public void Clear()
+    {
+        for (int x = 0; x < Size; x++)
+            for (int y = 0; y < Size; y++)
+                _cells[x, y] = CellState.Empty;
+        _ships.Clear();
+    }
+
+    public bool CanPlaceShip(int x, int y, int length, Orientation orientation)
+    {
+        for (int i = 0; i < length; i++)
+        {
+            int nx = x + (orientation == Orientation.Horizontal ? i : 0);
+            int ny = y + (orientation == Orientation.Vertical ? i : 0);
+            if (nx < 0 || nx >= Size || ny < 0 || ny >= Size)
+                return false;
+            if (_cells[nx, ny] != CellState.Empty)
+                return false;
+            for (int dx = -1; dx <= 1; dx++)
+                for (int dy = -1; dy <= 1; dy++)
+                {
+                    int sx = nx + dx;
+                    int sy = ny + dy;
+                    if (sx < 0 || sx >= Size || sy < 0 || sy >= Size)
+                        continue;
+                    if (_cells[sx, sy] == CellState.Ship)
+                        return false;
+                }
+        }
+        return true;
+    }
+
+    public bool PlaceShip(int x, int y, int length, Orientation orientation)
+    {
+        if (!CanPlaceShip(x, y, length, orientation))
+            return false;
+        var ship = new Ship(length, x, y, orientation);
+        _ships.Add(ship);
+        foreach (var (sx, sy) in ship.Coordinates)
+            _cells[sx, sy] = CellState.Ship;
+        return true;
+    }
+
+    public void AutoPlaceShips()
+    {
+        Clear();
+        var rnd = Random.Shared;
+        foreach (var size in _shipSizes)
+        {
+            bool placed = false;
+            while (!placed)
+            {
+                int x = rnd.Next(Size);
+                int y = rnd.Next(Size);
+                var orientation = rnd.Next(2) == 0 ? Orientation.Horizontal : Orientation.Vertical;
+                placed = PlaceShip(x, y, size, orientation);
+            }
+        }
+    }
+
+    public ShotResult Shoot(int x, int y)
+    {
+        if (x < 0 || x >= Size || y < 0 || y >= Size)
+            return ShotResult.Miss;
+        switch (_cells[x, y])
+        {
+            case CellState.Empty:
+                _cells[x, y] = CellState.Miss;
+                return ShotResult.Miss;
+            case CellState.Ship:
+                _cells[x, y] = CellState.Hit;
+                var ship = _ships.First(s => s.Contains(x, y));
+                ship.RegisterHit();
+                if (ship.IsSunk)
+                {
+                    MarkSurroundings(ship);
+                    return ShotResult.Sunk;
+                }
+                return ShotResult.Hit;
+            case CellState.Hit:
+            case CellState.Miss:
+                return ShotResult.AlreadyTried;
+            default:
+                return ShotResult.Miss;
+        }
+    }
+
+    private void MarkSurroundings(Ship ship)
+    {
+        foreach (var (x, y) in ship.Coordinates)
+        {
+            for (int dx = -1; dx <= 1; dx++)
+            for (int dy = -1; dy <= 1; dy++)
+            {
+                int nx = x + dx;
+                int ny = y + dy;
+                if (nx < 0 || nx >= Size || ny < 0 || ny >= Size)
+                    continue;
+                if (_cells[nx, ny] == CellState.Empty)
+                    _cells[nx, ny] = CellState.Miss;
+            }
+        }
+    }
+}

--- a/Battleship.Core/Enums.cs
+++ b/Battleship.Core/Enums.cs
@@ -1,0 +1,29 @@
+namespace Battleship.Core;
+
+public enum CellState
+{
+    Empty,
+    Ship,
+    Hit,
+    Miss
+}
+
+public enum Orientation
+{
+    Horizontal,
+    Vertical
+}
+
+public enum ShotResult
+{
+    Miss,
+    Hit,
+    Sunk,
+    AlreadyTried
+}
+
+public enum PlayerTurn
+{
+    Human,
+    Computer
+}

--- a/Battleship.Core/Game.cs
+++ b/Battleship.Core/Game.cs
@@ -1,9 +1,49 @@
+using System;
+
 namespace Battleship.Core;
 
 public class Game
 {
+    public Board PlayerBoard { get; } = new();
+    public Board ComputerBoard { get; } = new();
+    private readonly AiPlayer _ai = new();
+
+    public PlayerTurn CurrentTurn { get; private set; }
+    public bool Started { get; private set; }
+
+    public void NewGame()
+    {
+        PlayerBoard.Clear();
+        ComputerBoard.Clear();
+        _ai.AutoPlaceShips(ComputerBoard);
+        Started = false;
+    }
+
     public void Start()
     {
-        // TODO: Implement game logic
+        if (Started) return;
+        Started = true;
+        CurrentTurn = Random.Shared.Next(2) == 0 ? PlayerTurn.Human : PlayerTurn.Computer;
+    }
+
+    public ShotResult PlayerShoot(int x, int y)
+    {
+        if (!Started || CurrentTurn != PlayerTurn.Human)
+            return ShotResult.Miss;
+        var res = ComputerBoard.Shoot(x, y);
+        if (res == ShotResult.Miss || res == ShotResult.AlreadyTried)
+            CurrentTurn = PlayerTurn.Computer;
+        return res;
+    }
+
+    public ShotResult ComputerShoot()
+    {
+        if (!Started || CurrentTurn != PlayerTurn.Computer)
+            return ShotResult.Miss;
+        var (x, y) = _ai.ChooseShot(PlayerBoard);
+        var res = PlayerBoard.Shoot(x, y);
+        if (res == ShotResult.Miss || res == ShotResult.AlreadyTried)
+            CurrentTurn = PlayerTurn.Human;
+        return res;
     }
 }

--- a/Battleship.Core/Ship.cs
+++ b/Battleship.Core/Ship.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Battleship.Core;
+
+public class Ship
+{
+    public int Length { get; }
+    public List<(int x, int y)> Coordinates { get; }
+    public int Hits { get; private set; }
+
+    public Ship(int length, int startX, int startY, Orientation orientation)
+    {
+        Length = length;
+        Coordinates = new List<(int x, int y)>();
+        for (int i = 0; i < length; i++)
+        {
+            int x = startX + (orientation == Orientation.Horizontal ? i : 0);
+            int y = startY + (orientation == Orientation.Vertical ? i : 0);
+            Coordinates.Add((x, y));
+        }
+    }
+
+    public bool Contains(int x, int y) => Coordinates.Any(c => c.x == x && c.y == y);
+
+    public void RegisterHit() => Hits++;
+
+    public bool IsSunk => Hits >= Length;
+}

--- a/Battleship.Wpf/MainWindow.xaml
+++ b/Battleship.Wpf/MainWindow.xaml
@@ -1,12 +1,64 @@
-﻿<Window x:Class="Battleship.Wpf.MainWindow"
+<Window x:Class="Battleship.Wpf.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Battleship.Wpf"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
+        Title="Battleship" Height="600" Width="800">
+    <Window.Resources>
+        <Style x:Key="CellButtonStyle" TargetType="Button">
+            <Setter Property="Width" Value="30" />
+            <Setter Property="Height" Value="30" />
+            <Setter Property="Margin" Value="1" />
+            <Setter Property="Background" Value="LightBlue" />
+            <Setter Property="BorderBrush" Value="Gray" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="border" CornerRadius="4" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="LightSkyBlue" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="border" Property="Opacity" Value="0.6" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
     <Grid>
-
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="10" Grid.Row="0">
+            <Button x:Name="btnAutoPlace" Click="AutoPlace_Click">Авторасстановка</Button>
+            <Button x:Name="btnStart" Click="Start_Click" Margin="5,0,0,0" IsEnabled="False">Начать игру</Button>
+            <Button x:Name="btnRotate" Click="Rotate_Click" Margin="5,0,0,0">Повернуть</Button>
+            <TextBlock Text="Ход:" Margin="20,0,0,0" />
+            <TextBlock x:Name="txtTurn" Margin="5,0,0,0" />
+        </StackPanel>
+        <Grid Grid.Row="1" Margin="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <UniformGrid x:Name="playerGrid" Rows="10" Columns="10" />
+            <UniformGrid x:Name="enemyGrid" Grid.Column="2" Rows="10" Columns="10" />
+        </Grid>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="10" HorizontalAlignment="Center">
+            <TextBlock Text="Корабли игрока:" />
+            <TextBlock x:Name="txtPlayerShips" Margin="5,0,20,0" />
+            <TextBlock Text="Корабли компьютера:" />
+            <TextBlock x:Name="txtEnemyShips" Margin="5,0,0,0" />
+        </StackPanel>
     </Grid>
 </Window>

--- a/Battleship.Wpf/MainWindow.xaml.cs
+++ b/Battleship.Wpf/MainWindow.xaml.cs
@@ -1,24 +1,198 @@
-﻿using System.Text;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using Battleship.Core;
 
 namespace Battleship.Wpf
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
     public partial class MainWindow : Window
     {
+        private readonly Game _game = new();
+        private readonly Button[,] _playerButtons = new Button[Board.Size, Board.Size];
+        private readonly Button[,] _enemyButtons = new Button[Board.Size, Board.Size];
+        private readonly int[] _shipSizes = { 4, 3, 3, 2, 2, 2, 1, 1, 1, 1 };
+        private int _currentShipIndex = 0;
+        private Orientation _currentOrientation = Orientation.Horizontal;
+
         public MainWindow()
         {
             InitializeComponent();
+            InitBoards();
+            _game.NewGame();
+            UpdateShipLabels();
+        }
+
+        private void InitBoards()
+        {
+            for (int x = 0; x < Board.Size; x++)
+            for (int y = 0; y < Board.Size; y++)
+            {
+                var btn = new Button { Style = (Style)FindResource("CellButtonStyle") };
+                btn.Tag = (x, y);
+                btn.Click += PlayerCell_Click;
+                playerGrid.Children.Add(btn);
+                _playerButtons[x, y] = btn;
+
+                var enemyBtn = new Button { Style = (Style)FindResource("CellButtonStyle") };
+                enemyBtn.Tag = (x, y);
+                enemyBtn.Click += EnemyCell_Click;
+                enemyBtn.IsEnabled = false;
+                enemyGrid.Children.Add(enemyBtn);
+                _enemyButtons[x, y] = enemyBtn;
+            }
+        }
+
+        private void PlayerCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (_currentShipIndex >= _shipSizes.Length || _game.Started)
+                return;
+            var (x, y) = ((int, int))((Button)sender).Tag;
+            int length = _shipSizes[_currentShipIndex];
+            if (_game.PlayerBoard.PlaceShip(x, y, length, _currentOrientation))
+            {
+                foreach (var (sx, sy) in _game.PlayerBoard.Ships.Last().Coordinates)
+                    _playerButtons[sx, sy].Background = Brushes.Navy;
+                _currentShipIndex++;
+                if (_currentShipIndex >= _shipSizes.Length)
+                    btnStart.IsEnabled = true;
+                UpdateShipLabels();
+            }
+        }
+
+        private void EnemyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_game.Started || _game.CurrentTurn != PlayerTurn.Human)
+                return;
+            var (x, y) = ((int, int))((Button)sender).Tag;
+            var result = _game.PlayerShoot(x, y);
+            UpdateEnemyView();
+            UpdateShipLabels();
+            if (_game.ComputerBoard.ShipsRemaining == 0)
+            {
+                MessageBox.Show("Вы победили!", "Игра окончена");
+                DisableEnemyBoard();
+                return;
+            }
+            UpdateTurnLabel();
+            if (_game.CurrentTurn == PlayerTurn.Computer)
+                ComputerMove();
+        }
+
+        private void ComputerMove()
+        {
+            do
+            {
+                _ = _game.ComputerShoot();
+                UpdatePlayerView();
+                UpdateShipLabels();
+                if (_game.PlayerBoard.ShipsRemaining == 0)
+                {
+                    MessageBox.Show("Компьютер победил", "Игра окончена");
+                    DisableEnemyBoard();
+                    return;
+                }
+            } while (_game.CurrentTurn == PlayerTurn.Computer);
+            UpdateTurnLabel();
+        }
+
+        private void AutoPlace_Click(object sender, RoutedEventArgs e)
+        {
+            _game.PlayerBoard.Clear();
+            _game.PlayerBoard.AutoPlaceShips();
+            _currentShipIndex = _shipSizes.Length;
+            UpdatePlayerView();
+            btnStart.IsEnabled = true;
+            UpdateShipLabels();
+        }
+
+        private void Start_Click(object sender, RoutedEventArgs e)
+        {
+            _game.Start();
+            btnStart.IsEnabled = false;
+            btnAutoPlace.IsEnabled = false;
+            playerGrid.IsEnabled = false;
+            EnableEnemyBoard();
+            UpdateTurnLabel();
+            if (_game.CurrentTurn == PlayerTurn.Computer)
+                ComputerMove();
+        }
+
+        private void Rotate_Click(object sender, RoutedEventArgs e)
+        {
+            _currentOrientation = _currentOrientation == Orientation.Horizontal ? Orientation.Vertical : Orientation.Horizontal;
+        }
+
+        private void UpdatePlayerView()
+        {
+            for (int x = 0; x < Board.Size; x++)
+            for (int y = 0; y < Board.Size; y++)
+            {
+                var state = _game.PlayerBoard.Cells[x, y];
+                var btn = _playerButtons[x, y];
+                switch (state)
+                {
+                    case CellState.Empty:
+                        btn.Background = Brushes.LightBlue;
+                        break;
+                    case CellState.Ship:
+                        btn.Background = Brushes.Navy;
+                        break;
+                    case CellState.Miss:
+                        btn.Background = Brushes.LightGray;
+                        btn.IsEnabled = false;
+                        break;
+                    case CellState.Hit:
+                        btn.Background = Brushes.Red;
+                        btn.IsEnabled = false;
+                        break;
+                }
+            }
+        }
+
+        private void UpdateEnemyView()
+        {
+            for (int x = 0; x < Board.Size; x++)
+            for (int y = 0; y < Board.Size; y++)
+            {
+                var state = _game.ComputerBoard.Cells[x, y];
+                var btn = _enemyButtons[x, y];
+                switch (state)
+                {
+                    case CellState.Miss:
+                        btn.Background = Brushes.LightGray;
+                        btn.IsEnabled = false;
+                        break;
+                    case CellState.Hit:
+                        btn.Background = Brushes.Red;
+                        btn.IsEnabled = false;
+                        break;
+                }
+            }
+        }
+
+        private void UpdateTurnLabel()
+        {
+            txtTurn.Text = _game.CurrentTurn == PlayerTurn.Human ? "Игрок" : "Компьютер";
+        }
+
+        private void UpdateShipLabels()
+        {
+            txtPlayerShips.Text = _game.PlayerBoard.ShipsRemaining.ToString();
+            txtEnemyShips.Text = _game.ComputerBoard.ShipsRemaining.ToString();
+        }
+
+        private void EnableEnemyBoard()
+        {
+            foreach (var btn in _enemyButtons)
+                btn.IsEnabled = true;
+            UpdateEnemyView();
+        }
+
+        private void DisableEnemyBoard()
+        {
+            foreach (var btn in _enemyButtons)
+                btn.IsEnabled = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add core game logic for boards, ships, and AI
- Build WPF interface with ship placement, auto setup, and turn handling
- Show remaining ship counts and basic win/lose messages

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cbdda9d08332b8105005e0d50e33